### PR TITLE
I've moved the Neo4j credentials to a `.env` file. Here's a summary o…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ auto_update.sh
 auto_commit.sh
 update_log.txt
 commit_log.txt
+
+# APGE specific environment file
+src/apge/.env

--- a/src/apge/etl.py
+++ b/src/apge/etl.py
@@ -1,4 +1,5 @@
 import os
+from dotenv import load_dotenv
 from typing import Dict, Any, List, Optional
 from neo4j import GraphDatabase, Driver, ManagedTransaction, unit_of_work
 from dataclasses import asdict
@@ -7,11 +8,15 @@ from dataclasses import asdict
 from graph_schema import Diagnosis, Symptom, Target, StimParams, Evidence, SCHEMA_VERSION
 
 # --- Configuration ---
-# For local development, replace with your Neo4j credentials and URI
-# In a production scenario, these should come from environment variables or a secure config
-NEO4J_URI = os.environ.get("NEO4J_URI", "neo4j://localhost:7687")
-NEO4J_USER = os.environ.get("NEO4J_USER", "neo4j")
-NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD", "yourStrongPassword") # Use the password you set up
+# --- Configuration ---
+load_dotenv() # Load environment variables from .env file
+
+NEO4J_URI = os.environ.get("NEO4J_URI")
+NEO4J_USER = os.environ.get("NEO4J_USER")
+NEO4J_PASSWORD = os.environ.get("NEO4J_PASSWORD")
+
+if NEO4J_PASSWORD is None:
+    raise ValueError("NEO4J_PASSWORD not found in environment variables. Please set it in the .env file or environment.")
 
 # Hardcoded protocolDatabase (converted from the user's JavaScript)
 # NOTE: In a real system, this would come from a file or another data source.

--- a/src/apge/requirements.txt
+++ b/src/apge/requirements.txt
@@ -1,3 +1,3 @@
 neo4j>=5.0.0,<6.0.0
 # Add other dependencies as needed, e.g., for config file parsing later
-# python-dotenv (if using .env for credentials)
+python-dotenv # (if using .env for credentials)


### PR DESCRIPTION
…f the changes:

- Added `python-dotenv` to your project's requirements.
- Created a `.env` file in `src/apge/` for the Neo4j credentials.
- Modified `etl.py` to load credentials from the `.env` file and removed the hardcoded defaults.
- Added `src/apge/.env` to your `.gitignore` file.