### PR TITLE
feat: Initial scaffold for Protocol Comparator feature

### DIFF
--- a/neurostream-ui/src/pages/ProtocolComparatorPage.stories.tsx
+++ b/neurostream-ui/src/pages/ProtocolComparatorPage.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ProtocolComparatorPage from './ProtocolComparatorPage';
+
+const meta = {
+  title: 'Pages/ProtocolComparatorPage',
+  component: ProtocolComparatorPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof ProtocolComparatorPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/neurostream-ui/src/pages/ProtocolComparatorPage.tsx
+++ b/neurostream-ui/src/pages/ProtocolComparatorPage.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+// Dummy data for the comparator
+const dummyComparatorData = {
+  table: {
+    columns: ["Protocol", "Coil Type", "Frequency", "Intensity", "Pulses", "Sessions", "Evidence"],
+    data: [
+      ["Protocol Alpha", "Figure-8", "10 Hz", "120% RMT", "3000", "20", "Level A"],
+      ["Protocol Beta", "H-Coil", "20 Hz", "110% RMT", "2000", "30", "Level B"],
+    ],
+  },
+  narrative_md: `## Comparison Narrative
+
+This is a **dummy narrative** for the protocol comparison.
+
+### Coil Physics
+Protocol Alpha uses a Figure-8 coil, while Protocol Beta uses an H-Coil.
+
+### Session Burden
+Protocol Alpha involves 20 sessions, whereas Protocol Beta involves 30 sessions.
+
+### Evidence Strength
+Protocol Alpha has Level A evidence, and Protocol Beta has Level B evidence.
+
+**Clinical Pearl:** Consider patient preference when choosing between these protocols.
+`
+};
+
+const ProtocolComparatorPage: React.FC = () => {
+  return (
+    <div>
+      <h1>Protocol Comparator</h1>
+
+      {/* Display selected IDs (dummy) */}
+      <div>
+        <h2>Selected Protocols:</h2>
+        <ul>
+          <li>Protocol Alpha (ID: p1_dummy)</li>
+          <li>Protocol Beta (ID: p2_dummy)</li>
+        </ul>
+      </div>
+
+      {/* Display table */}
+      <div>
+        <h2>Comparison Table</h2>
+        <table>
+          <thead>
+            <tr>
+              {dummyComparatorData.table.columns.map((column) => (
+                <th key={column}>{column}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {dummyComparatorData.table.data.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {row.map((cell, cellIndex) => (
+                  <td key={cellIndex}>{cell}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Display narrative */}
+      <div>
+        <h2>Narrative</h2>
+        <div style={{ border: '1px solid #ccc', padding: '10px', whiteSpace: 'pre-wrap' }}>
+          {dummyComparatorData.narrative_md}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProtocolComparatorPage;

--- a/scripts/migrations/V1__add_device_schema.cypher
+++ b/scripts/migrations/V1__add_device_schema.cypher
@@ -1,0 +1,18 @@
+// Add constraints for Device node
+CREATE CONSTRAINT ON (d:Device) ASSERT d.name IS UNIQUE;
+CREATE CONSTRAINT ON (d:Device) ASSERT d.manufacturer IS UNIQUE;
+
+// Add constraint for StimParams node
+CREATE CONSTRAINT ON (sp:StimParams) ASSERT sp.id IS UNIQUE;
+
+// Backfill data for existing entries
+// NeoStar
+MERGE (d1:Device {name: 'NeoStar', manufacturer: 'NeoStar', coil_type: 'figure-8', focality_mm: 'Unknown', fda_clearance_ids: []});
+// BrainsWay
+MERGE (d2:Device {name: 'BrainsWay', manufacturer: 'BrainsWay', coil_type: 'H-Coil', focality_mm: 'Unknown', fda_clearance_ids: []});
+// Magstim
+MERGE (d3:Device {name: 'Magstim', manufacturer: 'Magstim', coil_type: 'figure-8', focality_mm: 'Unknown', fda_clearance_ids: []});
+
+// Add DELIVERED_BY relationships (example, replace with actual logic)
+// MATCH (sp:StimParams {protocol_id: 'some_protocol_id'}), (d:Device {name: 'NeoStar'})
+// MERGE (sp)-[:DELIVERED_BY]->(d);

--- a/src/apge/graph_schema.py
+++ b/src/apge/graph_schema.py
@@ -58,11 +58,22 @@ class Evidence(BaseNode):
     pub_year: Optional[int] = None
     notes: Optional[str] = None  # Could include notes summarizing the evidence
 
+@dataclass
+class Device(BaseNode):
+    name: str  # e.g., "NeoStar", "BrainsWay", "Magstim"
+    manufacturer: str  # e.g., "NeoStar", "BrainsWay", "Magstim"
+    coil_type: str  # e.g., "figure-8", "H-Coil"
+    focality_mm: str  # e.g., "5-10mm", "Deep and broad", "Unknown"
+    fda_clearance_ids: List[str] = field(default_factory=list) # e.g., ["K123456", "K789012"]
+    # Relationships:
+    # (:StimParams)-[:DELIVERED_BY]->(:Device)
+
 # --- Relationships to be established in the graph ---
 # (d:Diagnosis)-[:HAS_SYMPTOM]->(s:Symptom)
 # (s:Symptom)-[:TARGETED_BY]->(t:Target)
 # (t:Target)-[:USUALLY_TREATED_WITH]->(sp:StimParams)
 # (sp:StimParams)-[:SUPPORTED_BY]->(e:Evidence)
+# (sp:StimParams)-[:DELIVERED_BY]->(d:Device)
 
 # Example of how these might be used (conceptual, not for this file):
 # diagnosis_node = Diagnosis(name="Major Depressive Disorder")

--- a/src/apge/main.py
+++ b/src/apge/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI, Body
+from typing import List, Dict, Any
+
+app = FastAPI() # Assuming your FastAPI app instance is named 'app'
+
+@app.get("/api/protocol/list")
+async def list_protocols(diagnosis: str = ""):
+    # Dummy data for now
+    return [
+        {"id": "p1", "label": "Protocol 1", "device": "Device A", "evidence_level": "High"},
+        {"id": "p2", "label": "Protocol 2", "device": "Device B", "evidence_level": "Medium"},
+    ]
+
+@app.post("/api/protocol/compare")
+async def compare_protocols(ids: List[str] = Body(..., embed=True)):
+    # Dummy data for now
+    return {
+        "table": {
+            "columns": ["Protocol", "Coil Type", "Frequency", "Intensity"],
+            "data": [
+                ["Protocol 1", "Figure-8", "10Hz", "120% RMT"],
+                ["Protocol 2", "H-Coil", "20Hz", "110% RMT"],
+            ]
+        },
+        "narrative_md": "This is a placeholder narrative comparing the selected protocols."
+    }


### PR DESCRIPTION
Implements the initial backend and frontend stubs for the Protocol Comparator.

Backend:
- Adds `Device` node to Neo4j schema (`src/apge/graph_schema.py`) with properties: `name`, `manufacturer`, `coil_type`, `focality_mm`, `fda_clearance_ids`.
- Adds `DELIVERED_BY` relationship from `StimParams` to `Device`.
- Creates a Cypher migration script (`scripts/migrations/V1__add_device_schema.cypher`) for `Device` schema, constraints, and initial data backfill for NeoStar, BrainsWay, and Magstim.
- Stubs API endpoints in `src/apge/main.py`:
    - `GET /api/protocol/list`: Returns a dummy list of protocols.
    - `POST /api/protocol/compare`: Accepts protocol IDs and returns dummy comparison data.

Frontend:
- Scaffolds `ProtocolComparatorPage.tsx` in `neurostream-ui/src/pages/` with dummy table and narrative data.
- Adds `ProtocolComparatorPage.stories.tsx` for Storybook integration.

This commit addresses the S-1 sprint tasks: schema + migration, stubbed API endpoints, and scaffolded React component as per the issue description.