### PR TITLE
feat: Implement search.py and convert_to_yaml.py

### DIFF
--- a/data/literature/20250603_transcranial_magnetic_stimulation_for_depression_results.json
+++ b/data/literature/20250603_transcranial_magnetic_stimulation_for_depression_results.json
@@ -1,0 +1,57 @@
+[
+    {
+        "title": "CAN TRANSCRANIAL MAGNETIC STIMULATION TREATMENT OF OBSESSIVE-COMPULSIVE DISORDER RELIEVE COMORBID DEPRESSION SYMPTOMS?",
+        "authors": [
+            "Ahmet Dalkilic",
+            "Sabriye Yilmaz",
+            "Ismail Safak",
+            "Alican Dalkilic"
+        ],
+        "doi": "10.1016/j.transm.2024.100062",
+        "year": 2024,
+        "abstract": "N/A"
+    },
+    {
+        "title": "FIRST EVALUATION TRAIL FOR REPETITIVE TRANSCRANIAL MAGNETIC STIMULATION FOR DRUG RESISTANT DEPRESSION IN WALES",
+        "authors": [
+            "Akhtar Khan",
+            "Billy Woods",
+            "Racheal Gemine",
+            "Richard Jones"
+        ],
+        "doi": "10.1016/j.transm.2024.100010",
+        "year": 2024,
+        "abstract": "N/A"
+    },
+    {
+        "title": "F3 MAPPING: ACCELERATED TMS IN A PATIENT WITH TREATMENT RESISTANT DEPRESSION",
+        "authors": [
+            "Adekola Alao"
+        ],
+        "doi": "10.1016/j.transm.2024.100036",
+        "year": 2024,
+        "abstract": "N/A"
+    },
+    {
+        "title": "Spontaneous resolution of nausea and vomiting in cyclic vomiting syndrome following repetitive transcranial magnetic stimulation for treatment-resistant depression: A case report",
+        "authors": [
+            "Ghida Kassir",
+            "Amer M. Burhan"
+        ],
+        "doi": "10.1016/j.transm.2025.100170",
+        "year": 2025,
+        "abstract": "N/A"
+    },
+    {
+        "title": "SEQUENTIAL MULTI-LOCUS TRANSCRANIAL MAGNETIC STIMULATION FOR TREATMENT OF OBSESSIVE-COMPULSIVE DISORDER WITH COMORBID MAJOR DEPRESSION: A CASE SERIES",
+        "authors": [
+            "Alican Dalkilic",
+            "Maureen Haque",
+            "Nataliya Stoilova Yavas",
+            "Hatice Burakgazi Yilmaz"
+        ],
+        "doi": "10.1016/j.transm.2024.100048",
+        "year": 2024,
+        "abstract": "N/A"
+    }
+]

--- a/ingest/convert_to_yaml.py
+++ b/ingest/convert_to_yaml.py
@@ -1,34 +1,175 @@
-# Placeholder for ingest/convert_to_yaml.py
-# This script will be used to convert approved rows from a data source
-# (e.g., Airtable or an Excel file) into YAML chunks for protocol ingestion.
-# It is intended to use Jinja templates for formatting the YAML output.
+# ingest/convert_to_yaml.py
 
 import argparse
-import sys
+import csv
+import os
+import re
+import yaml # PyYAML for YAML dumping
+from jinja2 import Environment, FileSystemLoader # Jinja2 for templating
 
-def main(args):
-    print("Placeholder script: convert_to_yaml.py")
-    print("This script is not yet implemented.")
-    print(f"Input file (example): {args.input_file}")
-    print(f"Output directory (example): {args.output_dir}")
-    # Future implementation will involve:
-    # 1. Reading data from the input file.
-    # 2. Using Jinja templates to format the data into YAML.
-    # 3. Writing the YAML output to the specified directory.
-    return 0
+# --- Helper Functions ---
+def slugify_filename(text):
+    """Convert text to a safe YAML filename (CamelCase, no special chars)."""
+    text = text.replace('-', ' ').replace('_', ' ') # Treat hyphens/underscores as spaces
+    # Capitalize first letter of each word
+    text = "".join(word.capitalize() for word in text.split())
+    text = re.sub(r'[^a-zA-Z0-9]', '', text) # Remove non-alphanumeric
+    return text if text else "UnnamedDiagnosis"
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Convert structured data to protocol YAML files.")
-    parser.add_argument("-i", "--input-file", help="Path to the input data file (e.g., CSV, Excel).")
-    parser.add_argument("-o", "--output-dir", help="Directory to save the generated YAML files.")
-    # Add more arguments as needed for Jinja template path, etc.
+def parse_nullable_float(value_str):
+    """Convert string to float, or return None if empty/invalid."""
+    if value_str and value_str.strip():
+        try:
+            return float(value_str.strip())
+        except ValueError:
+            return None # Or raise error, depending on strictness
+    return None
 
-    if len(sys.argv) == 1:
-        # Provide default help if no arguments are given,
-        # or if you want to show that it's a placeholder.
-        parser.print_help(sys.stderr)
-        print("\nThis is a placeholder script and requires actual arguments and implementation to run correctly.")
-        sys.exit(0)
+def parse_frequency(value_str):
+    """
+    Return frequency as float if possible, otherwise as string.
+    This is to handle cases like "10" vs "10 (L) / 1 (R)".
+    In YAML, numbers should not be quoted, strings should.
+    Jinja template will handle quoting based on type if needed,
+    but easier to pass it ready.
+    For YAML output, numerical floats should be numbers, strings quoted.
+    """
+    if not value_str: return None
+    value_str = value_str.strip()
+    try:
+        return float(value_str)
+    except ValueError:
+        return value_str # Keep as string
+
+def format_for_yaml(value):
+    """Format value for YAML representation (numbers unquoted, null for None, strings quoted)."""
+    if value is None:
+        return 'null' # YAML null
+    if isinstance(value, (int, float)):
+        return str(value) # Return numbers as their string representation
+    # For string values that need to be output as YAML strings (i.e., quoted if they contain special characters)
+    # or as the literal 'null'.
+    return yaml.dump(str(value), allow_unicode=True).strip() # .strip() to remove trailing newline from dump
+
+# --- Main Conversion Logic ---
+def convert_csv_to_yaml(csv_filepath, template_dir, template_name, output_dir):
+    """
+    Converts data from a CSV file to multiple YAML files, one per diagnosis,
+    using a Jinja2 template.
+    """
+    if not os.path.exists(csv_filepath):
+        print(f"Error: CSV file not found at {csv_filepath}")
+        return
+
+    # Initialize Jinja2 environment
+    env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True, lstrip_blocks=True)
+    try:
+        template = env.get_template(template_name)
+    except Exception as e:
+        print(f"Error loading Jinja2 template '{template_name}' from '{template_dir}': {e}")
+        return
+
+    # Group protocols by diagnosis
+    diagnoses_data = {}
+
+    try:
+        with open(csv_filepath, mode='r', encoding='utf-8-sig') as csvfile: # utf-8-sig handles BOM
+            reader = csv.DictReader(csvfile)
+            if not reader.fieldnames:
+                print(f"Error: CSV file {csv_filepath} is empty or has no header row.")
+                return
+
+            expected_cols = [
+                'diagnosis', 'protocol_id', 'target', 'pattern', 'frequency_hz',
+                'intensity_pct_mt', 'intensity_pct_amt', 'pulses', 'train_s', 'iti_s',
+                'sessions', 'schedule', 'evidence_level', 'evidence_refs'
+            ]
+            missing_cols = [col for col in expected_cols if col not in reader.fieldnames]
+            if missing_cols:
+                print(f"Error: CSV missing expected columns: {', '.join(missing_cols)}")
+                return
+
+            for row_num, row in enumerate(reader, 1):
+                diagnosis = row.get('diagnosis', '').strip()
+                protocol_id = row.get('protocol_id', '').strip()
+
+                if not diagnosis or not protocol_id:
+                    print(f"Warning: Skipping row {row_num} due to missing diagnosis or protocol_id.")
+                    continue
+
+                if diagnosis not in diagnoses_data:
+                    diagnoses_data[diagnosis] = {}
+
+                intensity_mt = parse_nullable_float(row.get('intensity_pct_mt'))
+                intensity_amt = parse_nullable_float(row.get('intensity_pct_amt'))
+
+                protocol_details = {
+                    'target': row.get('target', '').strip(),
+                    'pattern': row.get('pattern', '').strip(),
+                    'frequency_hz': parse_frequency(row.get('frequency_hz')),
+                    'intensity_pct_mt': intensity_mt,
+                    'intensity_pct_amt': intensity_amt,
+                    'pulses': int(row.get('pulses', 0)) if row.get('pulses', '').strip() else 0,
+                    'train_s': parse_nullable_float(row.get('train_s')),
+                    'iti_s': parse_nullable_float(row.get('iti_s')),
+                    'sessions': row.get('sessions', '').strip(),
+                    'schedule': row.get('schedule', '').strip(),
+                    'evidence_level': row.get('evidence_level', '').strip(),
+                    'evidence_refs': [ref.strip() for ref in row.get('evidence_refs', '').split(';') if ref.strip()]
+                }
+                protocol_details['frequency_hz_yaml'] = format_for_yaml(protocol_details['frequency_hz'])
+                protocol_details['train_s_yaml'] = format_for_yaml(protocol_details['train_s'])
+                protocol_details['iti_s_yaml'] = format_for_yaml(protocol_details['iti_s'])
+
+                if protocol_id in diagnoses_data[diagnosis]:
+                    print(f"Warning: Duplicate protocol_id '{protocol_id}' for diagnosis '{diagnosis}'. Overwriting.")
+
+                diagnoses_data[diagnosis][protocol_id] = protocol_details
+
+    except FileNotFoundError:
+        print(f"Error: CSV file not found at {csv_filepath}")
+        return
+    except Exception as e:
+        print(f"Error reading or processing CSV file {csv_filepath}: {e}")
+        return
+
+    if not diagnoses_data:
+        print("No data processed from CSV.")
+        return
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+        print(f"Created output directory: {output_dir}")
+
+    for diagnosis_name, protocols in diagnoses_data.items():
+        yaml_filename = f"{slugify_filename(diagnosis_name)}.yaml"
+        yaml_filepath = os.path.join(output_dir, yaml_filename)
+
+        context = {
+            'diagnosis_name': diagnosis_name,
+            'protocols': protocols
+        }
+
+        try:
+            rendered_yaml_content = template.render(context)
+            # For more robust YAML (especially with complex strings or types), parse and re-dump:
+            # loaded_content = yaml.safe_load(rendered_yaml_content)
+            # with open(yaml_filepath, 'w', encoding='utf-8') as f:
+            #    yaml.dump(loaded_content, f, sort_keys=False, allow_unicode=True, indent=2, default_flow_style=False)
+            # Sticking to direct template output for this version:
+            with open(yaml_filepath, 'w', encoding='utf-8') as f:
+                f.write(rendered_yaml_content)
+            print(f"Successfully generated YAML for '{diagnosis_name}' at: {yaml_filepath}")
+        except Exception as e:
+            print(f"Error rendering or writing YAML for diagnosis '{diagnosis_name}': {e}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert curated CSV data to protocol YAML files.")
+    parser.add_argument("--input", required=True, help="Path to the input CSV data file.")
+    parser.add_argument("--output_dir", required=True, help="Directory to save the generated YAML files.")
+    parser.add_argument("--template_dir", default="ingest/", help="Directory containing the Jinja2 template. Defaults to 'ingest/'.")
+    parser.add_argument("--template_name", default="protocol_template.yaml.j2", help="Name of the Jinja2 template file. Defaults to 'protocol_template.yaml.j2'.")
 
     args = parser.parse_args()
-    sys.exit(main(args))
+
+    convert_csv_to_yaml(args.input, args.template_dir, args.template_name, args.output_dir)

--- a/ingest/protocol_template.yaml.j2
+++ b/ingest/protocol_template.yaml.j2
@@ -1,0 +1,28 @@
+# Schema version can be hardcoded or passed if needed
+# schema_version: 1.0
+
+{{ diagnosis_name }}:
+{% for protocol_id, details in protocols.items() %}
+  {{ protocol_id }}:
+    target: "{{ details.target }}"
+    pattern: "{{ details.pattern }}"
+    frequency_hz: {{ details.frequency_hz_yaml }}
+    {% if details.intensity_pct_mt %}
+    intensity_pct_mt: {{ details.intensity_pct_mt }}
+    {% elif details.intensity_pct_amt %}
+    intensity_pct_amt: {{ details.intensity_pct_amt }}
+    {% endif %}
+    pulses: {{ details.pulses }}
+    train_s: {{ details.train_s_yaml }}
+    iti_s: {{ details.iti_s_yaml }}
+    sessions: "{{ details.sessions }}"
+    schedule: "{{ details.schedule }}"
+    evidence_level: "{{ details.evidence_level }}"
+    evidence_refs:
+{% for ref in details.evidence_refs %}
+      - "{{ ref }}"
+{% endfor %}
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}

--- a/ingest/search.py
+++ b/ingest/search.py
@@ -1,0 +1,178 @@
+# ingest/search.py
+
+import argparse
+import datetime
+import json
+import os
+import requests # For making HTTP requests
+import re
+
+# --- Configuration ---
+# CrossRef API endpoint
+CROSSREF_API_URL = "https://api.crossref.org/works"
+# Email for polite API usage (replace with a real one if available, or a generic one)
+POLITE_EMAIL = "user@example.com"
+
+# --- Helper Functions ---
+def slugify(text):
+    """Convert text to a URL-friendly slug."""
+    text = text.lower()
+    text = re.sub(r'\s+', '_', text)      # Replace whitespace with underscores
+    text = re.sub(r'[^\w-]', '', text)   # Remove non-alphanumeric characters (except underscore/hyphen)
+    return text
+
+def ensure_dir_exists(directory_path):
+    """Create directory if it doesn't exist."""
+    if not os.path.exists(directory_path):
+        os.makedirs(directory_path)
+        print(f"Created directory: {directory_path}")
+
+def format_date_for_crossref(date_str):
+    """
+    Validates and formats a date string (YYYY-MM-DD) for CrossRef API.
+    CrossRef uses separate from-pub-date and until-pub-date.
+    If 'since' is provided, it means from this date up to today.
+    Returns a tuple (from_date, until_date) or None if invalid.
+    """
+    try:
+        # Attempt to parse YYYY-MM-DD
+        dt = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
+        return str(dt) # Returns YYYY-MM-DD string
+    except ValueError:
+        # Could add relative date parsing like '7d' here in the future
+        print(f"Error: Date '{date_str}' is not in YYYY-MM-DD format. Relative dates not yet supported by this script version.")
+        return None
+
+# --- Main Search Function ---
+def search_crossref(query, since_date_str=None, results_per_page=20):
+    """
+    Searches CrossRef API for literature.
+
+    Args:
+        query (str): The search query.
+        since_date_str (str, optional): Start date for filtering (YYYY-MM-DD).
+        results_per_page (int): Number of results per API request page. Max is usually 1000 for CrossRef.
+                                Using a smaller number like 20-100 for initial requests is common.
+
+    Returns:
+        list: A list of dictionaries, each representing a found article.
+    """
+    params = {
+        'query.bibliographic': query,
+        'rows': results_per_page,
+        'mailto': POLITE_EMAIL # Important for polite API usage
+    }
+
+    if since_date_str:
+        # CrossRef uses 'from-pub-date' for filtering from a specific date
+        # For a simple 'since', we effectively filter from 'since_date' to today.
+        # More complex date ranges would use 'until-pub-date' as well.
+        formatted_date = format_date_for_crossref(since_date_str)
+        if not formatted_date:
+            return [] # Invalid date format
+        params['filter'] = f"from-pub-date:{formatted_date}"
+        # To get results *up to* today, we don't strictly need an until-pub-date
+        # unless we want to cap it at a specific past date.
+
+    headers = {
+        'User-Agent': f"NeuroStream Ingest Agent/1.0 ({POLITE_EMAIL})"
+    }
+
+    print(f"Querying CrossRef API with: {query}, Since: {since_date_str or 'Any date'}")
+
+    collected_items = []
+    try:
+        response = requests.get(CROSSREF_API_URL, params=params, headers=headers, timeout=20)
+        response.raise_for_status()  # Raises an exception for bad status codes (4XX or 5XX)
+
+        data = response.json()
+        items = data.get('message', {}).get('items', [])
+
+        if not items:
+            print("No results found for the query.")
+            return []
+
+        for item in items:
+            title = item.get('title', [""])[0] # Title is often a list
+            doi = item.get('DOI', '')
+
+            authors_list = []
+            if 'author' in item:
+                for author in item.get('author', []):
+                    name_parts = []
+                    if 'given' in author:
+                        name_parts.append(author['given'])
+                    if 'family' in author:
+                        name_parts.append(author['family'])
+                    if name_parts:
+                        authors_list.append(" ".join(name_parts))
+
+            # Get publication year
+            pub_date_parts = item.get('issued', {}).get('date-parts', [[None]])[0]
+            year = pub_date_parts[0] if pub_date_parts[0] else "N/A"
+
+            # Abstract (often not directly available or truncated in CrossRef general search)
+            # For full abstracts, individual DOI lookups or other APIs (like PubMed) might be needed.
+            # CrossRef's REST API documentation notes that abstracts are not consistently available.
+            abstract = item.get('abstract', 'N/A')
+            # Sometimes abstracts are nested, e.g. under 'container-title' or via specific relations.
+            # This MVP will take what's directly available.
+
+            collected_items.append({
+                'title': title,
+                'authors': authors_list,
+                'doi': doi,
+                'year': year,
+                'abstract': abstract.strip().lstrip("<jats:p>").rstrip("</jats:p>") if abstract != "N/A" else "N/A" # Basic cleanup
+            })
+
+        print(f"Successfully retrieved {len(collected_items)} articles.")
+
+    except requests.exceptions.RequestException as e:
+        print(f"API request failed: {e}")
+        return []
+    except json.JSONDecodeError:
+        print("Failed to decode JSON response from API.")
+        return []
+
+    return collected_items
+
+# --- Script Execution ---
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Search CrossRef for scientific literature.")
+    parser.add_argument("--query", type=str, required=True, help="The search query (e.g., 'rTMS Major Depressive Disorder').")
+    parser.add_argument("--since", type=str, help="Optional start date for search (YYYY-MM-DD). Filters articles published from this date onwards.")
+    parser.add_argument("--out", type=str, help="Output JSON file path. If not provided, defaults to 'data/literature/{yyyymmdd}_{query_slug}_results.json'.")
+    parser.add_argument("--results", type=int, default=20, help="Number of results to fetch (max typically 1000 for CrossRef, default 20).")
+
+    args = parser.parse_args()
+
+    # Determine output path
+    output_dir = os.path.join("data", "literature")
+    ensure_dir_exists(output_dir)
+
+    if args.out:
+        output_file_path = args.out
+        # Ensure directory for custom output path also exists
+        custom_output_dir = os.path.dirname(output_file_path)
+        if custom_output_dir: # If output_file_path includes a directory
+             ensure_dir_exists(custom_output_dir)
+    else:
+        today_str = datetime.date.today().strftime("%Y%m%d")
+        query_slug = slugify(args.query)
+        output_filename = f"{today_str}_{query_slug}_results.json"
+        output_file_path = os.path.join(output_dir, output_filename)
+
+    # Perform search
+    results = search_crossref(args.query, args.since, results_per_page=args.results)
+
+    # Save results
+    if results:
+        try:
+            with open(output_file_path, 'w', encoding='utf-8') as f:
+                json.dump(results, f, indent=4, ensure_ascii=False)
+            print(f"Results saved to: {output_file_path}")
+        except IOError as e:
+            print(f"Error writing to output file {output_file_path}: {e}")
+    else:
+        print("No results to save.")


### PR DESCRIPTION
This commit delivers the functional Python scripts for your ingestion pipeline:

- `ingest/search.py`: Implements literature search functionality using the CrossRef API. It accepts query terms, date filters, and an output file argument, saving results in JSON format to `data/literature/`.

- `ingest/convert_to_yaml.py`: Replaces the placeholder with a full implementation for converting curated CSV data into YAML protocol files. It uses a Jinja2 template (`ingest/protocol_template.yaml.j2`) to structure the output, generating one YAML file per diagnosis in the `ingest/protocols/` directory. The script handles various data types, nullable fields, and specific formatting requirements for YAML.

- `ingest/protocol_template.yaml.j2`: The Jinja2 template used by `convert_to_yaml.py` to ensure consistent YAML output.

These scripts fulfill the core requirements for automating the initial stages of protocol data ingestion.