### PR TITLE
Fix hyphen in first study entry

### DIFF
--- a/data/studies.json
+++ b/data/studies.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "10.3389/fpsyt.2024.1514153",
-    "title": "Near-infrared spectroscopy--guided personalized repetitive transcranial magnetic stimulation for bipolar depression: a case report",
+    "title": "Near-infrared spectroscopy-guided personalized repetitive transcranial magnetic stimulation for bipolar depression: a case report",
     "journal": "Frontiers in Psychiatry",
     "year": 2025,
     "n": null,


### PR DESCRIPTION
## Summary
- correct double hyphen in the first study title in `studies.json`
- validate JSON remains well-formed

## Testing
- `jq '.' data/studies.json`

------
https://chatgpt.com/codex/tasks/task_e_683f40bef0f88327b65d261f1f6bbccc