### PR TITLE
Fix ANY usage in tests

### DIFF
--- a/src/apge/tests/test_api.py
+++ b/src/apge/tests/test_api.py
@@ -500,7 +500,7 @@ def test_compare_protocols_with_incomplete_data(mock_redis, MockOpenAI, mock_get
 
     assert data["narrative_md"] == "LLM-generated narrative will be here in S-3."
 
-    mock_db_session.run.assert_called_once_with(unittest.mock.ANY, ids=payload["ids"])
+    mock_db_session.run.assert_called_once_with(ANY, ids=payload["ids"])
 
     app.dependency_overrides = {}
 


### PR DESCRIPTION
## Summary
- replace `unittest.mock.ANY` usage in tests with `ANY`
- ensure `ANY` imported from `unittest.mock`

## Testing
- `pip install -r src/apge/requirements.txt`
- `PYTHONPATH=. pytest -q` *(fails: expected 'except' or 'finally' block)*

------
https://chatgpt.com/codex/tasks/task_e_683f40ce84748327bdbcd8afc9c87b01